### PR TITLE
Add isotope selector page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,7 @@
-# neutron_reaction
+# Neutron Reaction
+
+This repository contains a basic HTML page for selecting isotopes. The isotopes are loaded from a JSON file. 
+
+Currently the isotopes list is a small sample. To use a full dataset, replace `isotopes.json` with a comprehensive list of known isotopes.
+
+To view the page locally, open `index.html` in a browser.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Isotope Selector</title>
+<style>
+body { font-family: Arial, sans-serif; padding: 20px; }
+select { width: 300px; padding: 5px; }
+</style>
+</head>
+<body>
+<h1>Select an Isotope</h1>
+<select id="isotope-select"></select>
+
+<script>
+async function loadIsotopes() {
+  const response = await fetch('isotopes.json');
+  const isotopes = await response.json();
+  const select = document.getElementById('isotope-select');
+  isotopes.forEach(iso => {
+    const option = document.createElement('option');
+    option.value = `${iso.symbol}-${iso.mass_number}`;
+    option.textContent = `${iso.symbol}-${iso.mass_number} (${iso.name})`;
+    select.appendChild(option);
+  });
+}
+
+loadIsotopes();
+</script>
+</body>
+</html>

--- a/isotopes.json
+++ b/isotopes.json
@@ -1,0 +1,8 @@
+[
+  {"symbol": "H", "mass_number": 1, "name": "Hydrogen-1"},
+  {"symbol": "H", "mass_number": 2, "name": "Deuterium"},
+  {"symbol": "H", "mass_number": 3, "name": "Tritium"},
+  {"symbol": "He", "mass_number": 4, "name": "Helium-4"},
+  {"symbol": "C", "mass_number": 12, "name": "Carbon-12"},
+  {"symbol": "U", "mass_number": 235, "name": "Uranium-235"}
+]


### PR DESCRIPTION
## Summary
- add simple README
- add isotopes sample dataset
- create `index.html` that loads isotopes from JSON and populates a dropdown

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6842976570008331813da606a756eb12